### PR TITLE
Ensure payloads are not removed before parsing in `put_message`

### DIFF
--- a/src/net/messages.rs
+++ b/src/net/messages.rs
@@ -353,7 +353,6 @@ pub async fn put_message(
         // Send to source
         if is_self_send {
             if let Some(sender) = msg_bus.get(&source_pubkey_hash.to_vec()) {
-                // TODO: Why is this moving an immutable variable?
                 if let Err(err) = sender.send(raw_message_ws.clone()) {
                     warn!(message = "failed to broadcast to self", error = ?err);
                     // TODO: Make prettier


### PR DESCRIPTION
Currently, the put_message handler pops the payload off a message
prior to parsing it. However, it also does this before it tries
to parse the message, or store it. As such, if a message exceeds
500bytes, it will cause an error on message parse if the payload_digest
was not sent by the client. This commit moves the mutation until
after parsing, and after storing.