### PR TITLE
Ensure that the original message feed path is still valid

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -195,13 +195,20 @@ async fn main() {
         .and(warp::path(MESSAGES_PATH))
         .and(addr_protected.clone())
         .and(warp::ws())
-        .and(msg_bus_state)
+        .and(msg_bus_state.clone())
         .map(net::upgrade_ws);
+
     let websocket_feeds = warp::path(WS_PATH)
         .and(warp::path(FEEDS_PATH))
         .and(addr_base)
         .and(warp::ws())
         .and(feed_bus_state)
+        .map(net::upgrade_ws);
+
+    let websocket_messages_fallback = warp::path(WS_PATH)
+        .and(addr_protected.clone())
+        .and(warp::ws())
+        .and(msg_bus_state.clone())
         .map(net::upgrade_ws);
 
     // Profile handlers
@@ -268,6 +275,7 @@ async fn main() {
         .or(payments)
         .or(websocket_messages)
         .or(websocket_feeds)
+        .or(websocket_messages_fallback)
         .or(messages_get)
         .or(messages_delete)
         .or(messages_put)


### PR DESCRIPTION
Commit bb9d8e8d195cc68f18f404679a71d0252145616c added in a feeds
websocket subscription, and moved the messages path. This caused stamp
to no longer work at all. This commit adds a fallback to the original
websocket path in the default case.